### PR TITLE
Add missing task append feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,19 @@ bun run index.ts
 ```
 
 This project was created using `bun init` in bun v1.2.7. [Bun](https://bun.sh) is a fast all-in-one JavaScript runtime.
+
+## Tools
+
+### manage-task
+
+Edit a task in the markdown file.
+
+- `title`: task title
+- `original_text`: the text to search for
+- `edited_text`: the replacement text
+
+If `original_text` cannot be found, `edited_text` will be appended to the end of the task file.
+
+### get-task
+
+Retrieve tasks from the file. Provide `title` to get a specific task or omit it to list all top level tasks.

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1,6 +1,10 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { findAndReplace, find } from "./file-search-replace";
+import {
+  findAndReplace,
+  find,
+  ContentNotFoundError,
+} from "./file-search-replace";
 import * as fs from "fs/promises";
 
 // Ensure the task file exists, create if not
@@ -75,6 +79,14 @@ You should:
             content: [{ type: "text", text: `Task updated: ${params.title}` }],
           };
         } else if (result && result.err) {
+          if (result.err instanceof ContentNotFoundError) {
+            await fs.appendFile(filePath, `${params.edited_text}\n`);
+            return {
+              content: [
+                { type: "text", text: `Task added: ${params.title}` },
+              ],
+            };
+          }
           return {
             content: [{ type: "text", text: `Error: ${result.err.message}` }],
           };


### PR DESCRIPTION
## Summary
- append new tasks when `manage-task` can't find the original text
- document both tools

## Testing
- `bun run src/index.ts` *(fails: Cannot find module '@modelcontextprotocol/sdk/server/mcp.js')*