### PR TITLE
Refactor task path handling

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -4,7 +4,7 @@
                         "command": "bun",
                         "args": [
                                 "run",
-                                "src/index.ts"
+                                "~/repos/todo-mcp/src/index.ts"
                         ]
                 }
         }

--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,14 +1,11 @@
 {
-	"mcpServers": {
-		"task-service": {
-			"command": "bun",
-			"args": [
-				"run",
-				"~/repos/todo-mcp/src/index.ts"
-			],
-			"env": {
-				"TASK_FILE_PATH": "~/repos/todo-mcp/task.md"
-			}
-		}
-	}
+        "mcpServers": {
+                "task-service": {
+                        "command": "bun",
+                        "args": [
+                                "run",
+                                "src/index.ts"
+                        ]
+                }
+        }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 import * as path from "path";
-import { fileURLToPath } from "url";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { useTaskManagementTool } from "./tools";
@@ -11,8 +10,7 @@ async function main() {
     description: `A task management tool that helps humans and agents collaborate.
 This tool breaks down problems into atomic tasks step by step, recording them in a markdown file to facilitate task completion.`,
   });
-  const __dirname = path.dirname(fileURLToPath(import.meta.url));
-  const taskFilePath = path.join(__dirname, "..", "task.md");
+  const taskFilePath = path.join("/tmp/todo-mcp/", "task.md");
 
   useTaskManagementTool(server, taskFilePath);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import * as path from "path";
+import { fileURLToPath } from "url";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { useTaskManagementTool } from "./tools";
@@ -10,8 +11,8 @@ async function main() {
     description: `A task management tool that helps humans and agents collaborate.
 This tool breaks down problems into atomic tasks step by step, recording them in a markdown file to facilitate task completion.`,
   });
-  const defaultFilePath = path.join(process.cwd(), "task.md");
-  const taskFilePath = process.env.TASK_FILE_PATH || defaultFilePath;
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const taskFilePath = path.join(__dirname, "..", "task.md");
 
   useTaskManagementTool(server, taskFilePath);
 


### PR DESCRIPTION
## Summary
- use project-relative path for task.md
- update mcp config to run from repo root

## Testing
- `bun run src/index.ts` *(fails: exited early)*