### PR TITLE
Improve task append logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ This project was created using `bun init` in bun v1.2.7. [Bun](https://bun.sh) i
 Edit a task in the markdown file.
 
 - `title`: task title
-- `original_text`: the text to search for
+- `original_text`: the text to search for. When adding subtasks or updating a task, provide the exact text from the task file (include surrounding context if needed).
 - `edited_text`: the replacement text
 
-If `original_text` cannot be found, `edited_text` will be appended to the end of the task file.
+If `original_text` cannot be found, the content will be appended automatically.
 
 ### get-task
 

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1,10 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import {
-  findAndReplace,
-  find,
-  ContentNotFoundError,
-} from "./file-search-replace";
+import { findAndReplace, find } from "./file-search-replace";
 import * as fs from "fs/promises";
 
 // Ensure the task file exists, create if not
@@ -74,19 +70,15 @@ You should:
       try {
         const results = await findAndReplace([patch]);
         const result = results[0];
-        if (result && result.changed) {
+        if (result && result.appended) {
+          return {
+            content: [{ type: "text", text: `Task added: ${params.title}` }],
+          };
+        } else if (result && result.changed) {
           return {
             content: [{ type: "text", text: `Task updated: ${params.title}` }],
           };
         } else if (result && result.err) {
-          if (result.err instanceof ContentNotFoundError) {
-            await fs.appendFile(filePath, `${params.edited_text}\n`);
-            return {
-              content: [
-                { type: "text", text: `Task added: ${params.title}` },
-              ],
-            };
-          }
           return {
             content: [{ type: "text", text: `Error: ${result.err.message}` }],
           };


### PR DESCRIPTION
## Summary
- allow `findAndReplace` to append missing content and flag it
- simplify `manage-task` logic to rely on append flag
- document how to provide context and mention automatic append

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'fs/promises')*